### PR TITLE
Using import instead require to get component

### DIFF
--- a/src/__tests__/Foo-test.js
+++ b/src/__tests__/Foo-test.js
@@ -3,7 +3,7 @@ import { shallow, mount, render } from 'enzyme';
 
 jest.dontMock('../Foo');
 
-const Foo = require('../Foo');
+import Foo from '../Foo';
 
 describe("A suite", function() {
   it("contains spec with an expectation", function() {


### PR DESCRIPTION
Using require to get react component throws error.

Warning: React.createElement: type should not be null, undefined, boolean, or number. It should be a string (for DOM elements) or a ReactClass (for composite components).
Warning: Failed propType: Invalid prop `Component` supplied to `<<anonymous>>`.
Warning: React.createElement: type should not be null, undefined, boolean, or number. It should be a string (for DOM elements) or a ReactClass (for composite components).
 FAIL  src/**tests**/Foo-test.js (1.376s)
● A suite › it contains spec with an expectation
- Invariant Violation: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: object.
      at invariant (node_modules/fbjs/lib/invariant.js:39:15)
